### PR TITLE
api: prepare for HttpOnly cookies and guest access

### DIFF
--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -192,6 +192,23 @@ export class Urbit {
   }
 
   /**
+   * Gets the name of the ship accessible at this.url and stores it to this.ship
+   *
+   */
+  async getShipName(): Promise<void> {
+    if (this.ship) {
+      return Promise.resolve();
+    }
+
+    const nameResp = await fetch(`${this.url}/~/host`, {
+      method: 'get',
+      credentials: 'include',
+    });
+    const name = await nameResp.text();
+    this.ship = name.substring(1);
+  }
+
+  /**
    * Connects to the Urbit ship. Nothing can be done until this is called.
    * That's why we roll it into this.authenticate
    */
@@ -208,17 +225,21 @@ export class Urbit {
       method: 'post',
       body: `password=${this.code}`,
       credentials: 'include',
-    }).then((response) => {
+    }).then(async response => {
       if (this.verbose) {
         console.log('Received authentication response', response);
       }
+      if (response.status >= 200 && response.status < 300) {
+        throw new Error('Login failed with status ' + response.status);
+      }
       const cookie = response.headers.get('set-cookie');
-      if (!this.ship) {
+      if (!this.ship && cookie) {
         this.ship = new RegExp(/urbauth-~([\w-]+)/).exec(cookie)[1];
       }
       if (!isBrowser) {
         this.cookie = cookie;
       }
+      this.getShipName();
     });
   }
 

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -83,6 +83,11 @@ export class Urbit {
   ship?: string | null;
 
   /**
+   * Our identity, with which we are authenticated into the ship
+   */
+  our?: string | null;
+
+  /**
    * If verbose, logs output eagerly.
    */
   verbose?: boolean;
@@ -209,8 +214,27 @@ export class Urbit {
   }
 
   /**
+   * Gets the name of the ship accessible at this.url and stores it to this.ship
+   *
+   */
+  async getOurName(): Promise<void> {
+    if (this.our) {
+      return Promise.resolve();
+    }
+
+    const nameResp = await fetch(`${this.url}/~/name`, {
+      method: 'get',
+      credentials: 'include',
+    });
+    const name = await nameResp.text();
+    this.our = name.substring(1);
+  }
+
+  /**
    * Connects to the Urbit ship. Nothing can be done until this is called.
    * That's why we roll it into this.authenticate
+   * TODO  as of urbit/urbit#6561, this is no longer true, and we are able
+   *       to interact with the ship using a guest identity.
    */
   async connect(): Promise<void> {
     if (this.verbose) {
@@ -240,6 +264,7 @@ export class Urbit {
         this.cookie = cookie;
       }
       this.getShipName();
+      this.getOurName();
     });
   }
 


### PR DESCRIPTION
Two changes herein:

88d585e contains changes from urbit/urbit#5918, which had gotten lost during repo migration. Luckily, the Eyre change that necessitated these changes has been reverted, and has not yet been re-released. The code herein prepares the library to continue operating in the presence of `HttpOnly` cookies, whose contents we cannot read, by making an HTTP request to figure out the identity of the ship we're talking to.

b50bf40 adds `this.our`, which corresponds to the identity we're logged in as. This is in contract to `this.ship`, which corresponds to the ship we're talking to. In practice, given the structure of `this.connect` and `this.authenticate`, these will always be the same. We should consider changing those, though, to support the "guest access" introduced by urbit/urbit#6561, and the cross-ship authentication in a yet-to-be-written PR.

As it stands, this PR is a non-breaking change. Adding support for the new access modes will be a breaking change however, since it changes the semantics of `this.ship`.