### PR TITLE
tests: manually initialize the ship and our fields

### DIFF
--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -79,7 +79,7 @@ export class Urbit {
   private abort = new AbortController();
 
   /**
-   * Ship can be set, in which case we can do some magic stuff like send chats
+   * Identity of the ship we're connected to
    */
   ship?: string | null;
 

--- a/test/default.test.ts
+++ b/test/default.test.ts
@@ -27,6 +27,13 @@ function fakeSSE(messages: any[] = [], timeout = 0) {
 }
 
 const ship = '~sampel-palnet';
+function newUrbit(): Urbit {
+  let airlock = new Urbit('', '+code');
+  //NOTE  in a real environment, these get populated at the end of connect()
+  airlock.ship = airlock.our = ship.substring(1);
+  return airlock;
+}
+
 let eventId = 0;
 function event(data: any) {
   return `id:${eventId++}\ndata:${JSON.stringify(data)}\n\n`;
@@ -60,7 +67,7 @@ describe('Initialisation', () => {
   let airlock: Urbit;
   let fetchSpy: ReturnType<typeof jest.spyOn>;
   beforeEach(() => {
-    airlock = new Urbit('', '+code');
+    airlock = newUrbit();
   });
   afterEach(() => {
     fetchSpy.mockReset();
@@ -113,7 +120,7 @@ describe('subscription', () => {
 
   it('should subscribe', async () => {
     fetchSpy = jest.spyOn(window, 'fetch');
-    airlock = new Urbit('', '+code');
+    airlock = newUrbit();
     airlock.onOpen = jest.fn();
     const params = {
       app: 'app',
@@ -136,7 +143,7 @@ describe('subscription', () => {
   }, 800);
   it('should poke', async () => {
     fetchSpy = jest.spyOn(window, 'fetch');
-    airlock = new Urbit('', '+code');
+    airlock = newUrbit();
     airlock.onOpen = jest.fn();
     fetchSpy.mockImplementation(fakeFetch(() => fakeSSE([ack(1)])));
     const params = {
@@ -153,7 +160,7 @@ describe('subscription', () => {
 
   it('should nack poke', async () => {
     fetchSpy = jest.spyOn(window, 'fetch');
-    airlock = new Urbit('', '+code');
+    airlock = newUrbit();
     airlock.onOpen = jest.fn();
     fetchSpy
       .mockImplementationOnce(() =>


### PR DESCRIPTION
During normal operation, connect() will trigger the filling of these values. Since the tests never actually call connect() (or authenticate()), but some internal logic may still refer to the ship/our values, we manually fill them in when instantiating an Urbit.