### PR TITLE
lib: resolve poke() calls eagerly, never throw

### DIFF
--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -586,22 +586,12 @@ export class Urbit {
       mark,
       json,
     };
-    const [send, result] = await Promise.all([
-      this.sendJSONtoChannel(message),
-      new Promise<number>((resolve, reject) => {
-        this.outstandingPokes.set(message.id, {
-          onSuccess: () => {
-            onSuccess();
-            resolve(message.id);
-          },
-          onError: (event) => {
-            onError(event);
-            reject(event.err);
-          },
-        });
-      }),
-    ]);
-    return result;
+    this.outstandingPokes.set(message.id, {
+      onSuccess: () => { onSuccess(); },
+      onError: (err) => { onError(err); },
+    });
+    await this.sendJSONtoChannel(message);
+    return message.id;
   }
 
   /**

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -149,6 +149,9 @@ export class Urbit {
    * then opens the channel via EventSource.
    *
    */
+  //TODO  rename this to connect() and only do constructor & event source setup.
+  //      that way it can be used with the assumption that you're already
+  //      authenticated.
   static async authenticate({
     ship,
     url,
@@ -237,6 +240,7 @@ export class Urbit {
    * TODO  as of urbit/urbit#6561, this is no longer true, and we are able
    *       to interact with the ship using a guest identity.
    */
+  //TODO  rename to authenticate() and call connect() at the end
   async connect(): Promise<void> {
     if (this.verbose) {
       console.log(


### PR DESCRIPTION
Previously, the poke() function was asynchronous on _both_ its PUT
request _and_ the poke-n/ack. In the nack case, it would *reject* the
latter promise instead of resolving it, causing the whole to throw an
error. Due to implementation mishap, this would always throw undefined.

Here, we update this behavior, so that it's asynchronous on _only_ the
PUT request, and returns the event id as soon as that resolves. The
callbacks passed as arguments still get called as normal.

This misbehavior was discovered while finishing the implementation of
the "handle poke nack" test, whose final form has been included.

Note that this is a subtle **breaking change**. Clients who were awaiting on
their poke() call will now see different/faster behavior, and no longer
need to fold it into a catch block.