### PR TITLE
reconnection: handle channel reap correctly

### DIFF
--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -404,8 +404,8 @@ export class Urbit {
     // called if a channel was reaped by %eyre before we reconnected
     // so we have to make a new channel.
     this.uid = `${Math.floor(Date.now() / 1000)}-${hexString(6)}`;
-    this.emit('status-update', { status: 'initial' });
     this.emit('seamless-reset', { uid: this.uid });
+    this.emit('status-update', { status: 'initial' });
     this.sseClientInitialized = false;
     this.lastEventId = 0;
     this.lastHeardEventId = -1;

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -426,7 +426,6 @@ export class Urbit {
       poke.onError('Channel was reaped');
     });
     this.outstandingPokes = new Map();
-    this.eventSource();
   }
 
   /**

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -359,7 +359,6 @@ export class Urbit {
           this.errorCount++;
           this.emit('error', { time: Date.now(), msg: JSON.stringify(error) });
           if (error instanceof ReapError) {
-            this.emit('status-update', { status: 'initial' });
             this.seamlessReset();
             return;
           }
@@ -405,6 +404,7 @@ export class Urbit {
     // called if a channel was reaped by %eyre before we reconnected
     // so we have to make a new channel.
     this.uid = `${Math.floor(Date.now() / 1000)}-${hexString(6)}`;
+    this.emit('status-update', { status: 'initial' });
     this.emit('seamless-reset', { uid: this.uid });
     this.sseClientInitialized = false;
     this.lastEventId = 0;

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -409,7 +409,9 @@ export class Urbit {
     this.lastEventId = 0;
     this.lastHeardEventId = -1;
     this.lastAcknowledgedEventId = -1;
-    this.outstandingSubscriptions.forEach((sub, id) => {
+    const oldSubs = [...this.outstandingSubscriptions.entries()];
+    this.outstandingSubscriptions = new Map();
+    oldSubs.forEach(([id, sub]) => {
       sub.quit({
         id,
         response: 'quit',
@@ -419,12 +421,12 @@ export class Urbit {
         status: 'close',
       });
     });
-    this.outstandingSubscriptions = new Map();
 
     this.outstandingPokes.forEach((poke, id) => {
       poke.onError('Channel was reaped');
     });
     this.outstandingPokes = new Map();
+    this.eventSource();
   }
 
   /**

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -359,6 +359,7 @@ export class Urbit {
           this.errorCount++;
           this.emit('error', { time: Date.now(), msg: JSON.stringify(error) });
           if (error instanceof ReapError) {
+            this.emit('status-update', { status: 'initial' });
             this.seamlessReset();
             return;
           }

--- a/src/fetch-event-source/fetch.ts
+++ b/src/fetch-event-source/fetch.ts
@@ -128,7 +128,10 @@ export function fetchEventSource(
         ])) as Response;
 
         if (response.status === 404) {
-          throw new ReapError('Channel reaped');
+          onerror?.(new ReapError('Channel reaped'));
+          dispose();
+          resolve();
+          return;
         }
 
         if (response.status < 200 || response.status >= 300) {

--- a/src/fetch-event-source/fetch.ts
+++ b/src/fetch-event-source/fetch.ts
@@ -139,7 +139,6 @@ export function fetchEventSource(
         }
 
         await onopen(response, isReconnect);
-
         // reset reconnect status
         if (isReconnect) {
           isReconnect = false;


### PR DESCRIPTION
This finally resolves the issue around channel's reconnecting after being reaped. We previously attempted this but were still going through the retry path which was incorrect. This instead short-circuits and disposes of this fetch event source call to prefer the new one being created, and properly calls the quit events on subscriptions so that they restart.

My main question here is do we want something like an `onReap` handler that can be passed by callers of the library in cased they don't want to rely upon the subscriptions quitting?