### PR TITLE
Fix default fetch implementation for web

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/http-api",
-  "version": "3.1.0-dev",
+  "version": "3.1.0-dev-2",
   "license": "MIT",
   "description": "Library to interact with an Urbit ship over HTTP",
   "repository": "github:urbit/js-http-api",

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -98,6 +98,11 @@ export class Urbit {
    */
   private errorCount = 0;
 
+  /**
+   * Custom fetch implementation to use.
+   */
+  fetchFn: typeof fetch = (...args) => fetch(...args);
+
   onError?: (error: any) => void = null;
 
   onRetry?: () => void = null;
@@ -138,13 +143,13 @@ export class Urbit {
     public url: string,
     public code?: string,
     public desk?: string,
-    // The indirection here is necessary as browser fetch requires that it be
-    // executed with a `this` value of `window`.
-    // See: https://stackoverflow.com/questions/69876859/why-does-bind-fix-failed-to-execute-fetch-on-window-illegal-invocation-err
-    public fetchFn: typeof fetch = (...args) => fetch(...args)
+    fetchFn?: typeof fetch
   ) {
     if (isBrowser) {
       window.addEventListener('beforeunload', this.delete);
+    }
+    if (fetchFn) {
+      this.fetchFn = fetchFn;
     }
     return this;
   }

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -138,7 +138,10 @@ export class Urbit {
     public url: string,
     public code?: string,
     public desk?: string,
-    public fetchFn: typeof fetch = fetch
+    // The indirection here is necessary as browser fetch requires that it be
+    // executed with a `this` value of `window`.
+    // See: https://stackoverflow.com/questions/69876859/why-does-bind-fix-failed-to-execute-fetch-on-window-illegal-invocation-err
+    public fetchFn: typeof fetch = (...args) => fetch(...args)
   ) {
     if (isBrowser) {
       window.addEventListener('beforeunload', this.delete);


### PR DESCRIPTION
The way that we currently implement the default fetch configuration causes an `IllegalInvocationError` on web, as `fetch` needs to be executed with a `this` value of `window`. This PR fixes that by wrapping the global fetch, so that we're not storing the reference directly. It also ensures that we set a value for the fetch function, even if a falsy value is passed in.