### PR TITLE
Emit an event on channel reap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/http-api",
-  "version": "3.1.0-dev-2",
+  "version": "3.1.0-dev-3",
   "license": "MIT",
   "description": "Library to interact with an Urbit ship over HTTP",
   "repository": "github:urbit/js-http-api",

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -423,6 +423,7 @@ export class Urbit {
           this.errorCount++;
           this.emit('error', { time: Date.now(), msg: JSON.stringify(error) });
           if (error instanceof ReapError) {
+            this.emit('channel-reaped', { time: Date.now() });
             this.seamlessReset();
             return;
           }

--- a/src/events.ts
+++ b/src/events.ts
@@ -42,6 +42,10 @@ export interface InitEvent extends ResetEvent {
   subscriptions: Omit<SubscriptionEvent, 'status'>[];
 }
 
+export interface ChannelReapedEvent {
+  time: number;
+}
+
 export type UrbitHttpApiEvent = {
   subscription: SubscriptionEvent;
   'status-update': StatusUpdateEvent;
@@ -50,6 +54,7 @@ export type UrbitHttpApiEvent = {
   error: ErrorEvent;
   reset: ResetEvent;
   'seamless-reset': ResetEvent;
+  'channel-reaped': ChannelReapedEvent;
   init: InitEvent;
 };
 
@@ -61,4 +66,5 @@ export type UrbitHttpApiEventType =
   | 'error'
   | 'reset'
   | 'seamless-reset'
+  | 'channel-reaped'
   | 'init';


### PR DESCRIPTION
When we detect a closed channel and open a new one, we run through the seamless reconnect procedure. Right now, there's no way for consumers of the client to determine when those reconnects correspond to a reaped channel vs standard seamless reconnect. Distinguishing between these cases is important since a closed channel can lead to discontinuities in the connection.

This PR just adds a new `ChannelReapedEvent` type and emits it when we notice the channel was closed.

cc @arthyn 