### PR TITLE
api: automatic resubscribe by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@urbit/http-api",
-  "version": "3.0.0",
+  "version": "3.1.0-dev-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@urbit/http-api",
-      "version": "3.0.0",
+      "version": "3.1.0-dev-3",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
+        "@types/node": "^20.14.9",
         "browser-or-node": "^1.3.0",
         "core-js": "^3.19.1"
       },
@@ -22,7 +23,7 @@
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.0.6",
         "@types/browser-or-node": "^1.2.0",
-        "@types/eventsource": "^1.1.5",
+        "@types/eventsource": "^1.1.15",
         "@types/jest": "^26.0.24",
         "@types/react": "^16.9.56",
         "@typescript-eslint/eslint-plugin": "^4.7.0",
@@ -2766,9 +2767,9 @@
       "dev": true
     },
     "node_modules/@types/eventsource": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.6.tgz",
-      "integrity": "sha512-y4xcLJ+lcoZ6mN9ndSdKOWg24Nj5uQc4Z/NRdy3HbiGGt5hfH3RLwAXr6V+RzGzOljAk48a09n6iY4BMNumEng==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
+      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -2832,10 +2833,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
-      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==",
-      "dev": true
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.3",
@@ -9367,6 +9370,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -11748,9 +11756,9 @@
       "dev": true
     },
     "@types/eventsource": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.6.tgz",
-      "integrity": "sha512-y4xcLJ+lcoZ6mN9ndSdKOWg24Nj5uQc4Z/NRdy3HbiGGt5hfH3RLwAXr6V+RzGzOljAk48a09n6iY4BMNumEng==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
+      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
       "dev": true
     },
     "@types/graceful-fs": {
@@ -11814,10 +11822,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
-      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==",
-      "dev": true
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -16643,6 +16653,11 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbit/http-api",
-  "version": "3.1.0-dev-3",
+  "version": "3.2.0-dev",
   "license": "MIT",
   "description": "Library to interact with an Urbit ship over HTTP",
   "repository": "github:urbit/js-http-api",
@@ -40,7 +40,7 @@
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.0.6",
     "@types/browser-or-node": "^1.2.0",
-    "@types/eventsource": "^1.1.5",
+    "@types/eventsource": "^1.1.15",
     "@types/jest": "^26.0.24",
     "@types/react": "^16.9.56",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "@types/node": "^20.14.9",
     "browser-or-node": "^1.3.0",
     "core-js": "^3.19.1"
   }

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -406,13 +406,16 @@ export class Urbit {
               data.response === 'quit' &&
               this.outstandingSubscriptions.has(data.id)
             ) {
-              const funcs = this.outstandingSubscriptions.get(data.id);
-              funcs.quit(data);
+              const sub = this.outstandingSubscriptions.get(data.id);
+              sub.quit(data);
               this.outstandingSubscriptions.delete(data.id);
               this.emit('subscription', {
                 id: data.id,
                 status: 'close',
               });
+              if (sub.resubOnQuit) {
+                this.subscribe(sub);
+              }
             } else if (this.verbose) {
               console.log([...this.outstandingSubscriptions.keys()]);
               console.log('Unrecognized response', data);
@@ -560,7 +563,14 @@ export class Urbit {
           this.unsubscribe(id);
         }
       };
-      const request = { app, path, event, err: reject, quit };
+      const request = {
+        app,
+        path,
+        resubOnQuit: false,
+        event,
+        err: reject,
+        quit,
+      };
 
       id = await this.subscribe(request);
 
@@ -624,11 +634,12 @@ export class Urbit {
    * @param handlers Handlers to deal with various events of the subscription
    */
   async subscribe(params: SubscriptionRequestInterface): Promise<number> {
-    const { app, path, ship, err, event, quit } = {
+    const { app, path, ship, resubOnQuit, err, event, quit } = {
       err: () => {},
       event: () => {},
       quit: () => {},
       ship: this.ship,
+      resubOnQuit: true,
       ...params,
     };
 
@@ -647,6 +658,7 @@ export class Urbit {
     this.outstandingSubscriptions.set(message.id, {
       app,
       path,
+      resubOnQuit,
       err,
       event,
       quit,

--- a/src/Urbit.ts
+++ b/src/Urbit.ts
@@ -489,6 +489,10 @@ export class Urbit {
         id,
         status: 'close',
       });
+
+      if (sub.resubOnQuit) {
+        this.subscribe(sub);
+      }
     });
 
     this.outstandingPokes.forEach((poke, id) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,10 @@ export interface SubscriptionRequestInterface extends SubscriptionInterface {
    * `"/keys"`
    */
   path: Path;
+  /**
+   * Whether to resubscribe this exact subscription on quit
+   */
+  resubOnQuit?: boolean;
 }
 
 export interface headers {


### PR DESCRIPTION
In the Tlon app we had a `quit` handler which basically always resubscribes, however the problem with this is that the new subscription also needs to use the same `quit` handler. 

```typescript
client.subscribe({
  ...params,
  event: eventListener(params.event),
  quit: () => {
    this.client!.subscribe({
      ...params,
      event: eventListener(params.event),
      // quit: need the same quit handler here, recursively...
    });
```

Defining this recursively is awkward, and this behavior of resubscribing after quit is generally what any person using this would want. So to address this we add a new parameter to subscriptions `resubOnQuit` which defaults to true. If it is true it will first run the quit handler, then create a new subscription reusing the parameters originally given to it. This makes subscriptions more seamless. We offer a way out of this behavior by passing that parameter with `false`.

Notably, I think this solves the last source of silent disconnects that we were seeing.